### PR TITLE
Allow content to vary in height once opened

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -98,7 +98,7 @@ export default class extends Controller {
     if (opened) {
       toggler.classList.add('st-accordion__icon--opened');
       content.classList.add('st-accordion__content--visible');
-      content.style.height = content.scrollHeight + 'px';
+      content.style.height = 'unset';
     } else {
       toggler.classList.remove('st-accordion__icon--opened');
       content.classList.remove('st-accordion__content--visible');


### PR DESCRIPTION
This solves an issue where, if the accordion content changes scroll height (for example, if an element is added/removed dynamically, or the user resizes the browser window and css is applied to some element within the content), the height attribute of the st-accordion__content is not updated.

Instead of permanently fixing the height attribute of the st-accordion__content element to what its scrollHeight was at the time of opening the content, instead we should effectively undo the setting of the height to 0.

If the user of the library wishes to specify the height of the content element, this would be undone by the 'unset'. To avoid this, they can do one of these things:
- Specify the height of some other element instead (e.g. putting a 'container' div within the content)
- Use '!important' when they specify the height of the content element